### PR TITLE
Sync recipe to permamodel v0.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ install:
 - conda install python=$TRAVIS_PYTHON_VERSION
 - conda install -q conda-build anaconda-client coverage sphinx
 script:
-- conda build ./recipe -c csdms-stack -c conda-forge
+- travis_wait conda build ./recipe -c csdms-stack -c conda-forge
 after_success:
 - curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py
   > $HOME/anaconda_upload.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,7 @@ install:
 - conda install python=$TRAVIS_PYTHON_VERSION
 - conda install -q conda-build anaconda-client coverage sphinx
 script:
-- travis_wait conda build ./recipe -c csdms-stack -c conda-forge
+- travis_wait conda build ./recipe -c csdms-stack -c conda-forge --old-build-string
 after_success:
-- curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py
-  > $HOME/anaconda_upload.py
-- echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --token=-
+- curl https://raw.githubusercontent.com/csdms/ci-tools/master/anaconda_upload.py > $HOME/anaconda_upload.py
+- echo $ANACONDA_TOKEN | python $HOME/anaconda_upload.py ./recipe --channel=main --org=csdms-stack --old-build-string --token=-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "csdms-permamodel-ku" %}
-{% set version = "0.1" %}
+{% set version = "0.1.1" %}
 
 package:
   name: {{ name }}
@@ -7,6 +7,7 @@ package:
 
 source:
   git_url: https://github.com/permamodel/permamodel
+  git_rev: v{{ version }}
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,9 +13,11 @@ requirements:
   build:
     - bmi-babel
     - permamodel
+    - scipy <=0.18.1
   run:
     - bmi-babel
     - permamodel
+    - scipy <=0.18.1
     - matplotlib
 
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,11 +12,11 @@ source:
 requirements:
   build:
     - bmi-babel
-    - pymt
     - permamodel
   run:
     - bmi-babel
     - permamodel
+    - matplotlib
 
 test:
   requires:


### PR DESCRIPTION
This PR syncs the conda recipe with the current permamodel version. I also set `--old-build-string` on `conda build` to reduce the number of files stored in Anaconda Cloud. The dependencies were vexing: this recipe passed a few months ago. Now, I found that `matplotlib` needs to be included, and `scipy` set to a version lower than 19 (for this, see also https://github.com/csdms-stack/anugased-rectangular-recipe/issues/2). 